### PR TITLE
Focus on input when (+) clicked.

### DIFF
--- a/web/app/components/Modal.js
+++ b/web/app/components/Modal.js
@@ -30,8 +30,15 @@ export default class Modal extends Component {
   }
 
   toggleModal = () => {
+    if (!this.props.modal) {
+      setTimeout(this.focus, 0);
+    }
     this.props.setModal(!this.props.modal);
   };
+
+  focus = () => {
+    this.input.focus();
+  }
 
   render({ modal, network }) {
     return (


### PR DESCRIPTION
This enhancement is designed to make it easier to add a new location. After a user clicks (+) action, the toggleModal handler queues up the firing of a focus call to the text input element.

Please let me know if there's a different implementation pattern you'd prefer or other changes.

Great demo. Really love seeing some small code and some Push. Together is even better!